### PR TITLE
reformatted footer to add email

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -113,15 +113,15 @@ async function createConfig() {
                             ],
                         },
                         {
-                            title: 'Community',
+                            title: 'Contact Us',
                             items: [
                                 {
                                     label: 'Discord',
                                     href: 'https://discord.gg/lilith',
                                 },
                                 {
-                                    label: 'GitHub',
-                                    href: 'https://github.com/lilithmod',
+                                    label: 'lilithmod.xyz@gmail.com',
+                                    href: 'mailto:lilithmodxyz@gmail.com',
                                 },
                             ],
                         },
@@ -131,6 +131,10 @@ async function createConfig() {
                                 {
                                     label: 'Config',
                                     href: 'https://me.lilithmod.xyz',
+                                },
+                                {
+                                    label: 'GitHub',
+                                    href: 'https://github.com/lilithmod',
                                 },
                                 {
                                     label: 'Privacy Policy',


### PR DESCRIPTION
Stripe and paypal demand that an email we use with them is publicly visible on our website so I added the main one. If we want to create a separate business one to connect that we can do that to, but for now this will do.